### PR TITLE
Bump docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.9"
 
 services:
   speed-camera:


### PR DESCRIPTION
Addresses issues with older versions not handling the volumes properly.