### PR TITLE
Fix typoed variable name

### DIFF
--- a/sql-make-graph-count-totals.py
+++ b/sql-make-graph-count-totals.py
@@ -112,12 +112,11 @@ if len(sys.argv) > 1:
 def is_int(var):
     ''' Check if variable string can successfully be converted to an integer.
     '''
-    success = True
     try:
-        test = int(var)
+        int(var)
     except ValueError:
-        sucess = False
-    return success
+        return False
+    return True
 
 #----------------------------------------------------------------------------------------
 def get_timestamp_substr(total_by):

--- a/sql-make-graph-speed-ave.py
+++ b/sql-make-graph-speed-ave.py
@@ -112,12 +112,11 @@ if len(sys.argv) > 1:
 def is_int(var):
     ''' Check if variable string can successfully be converted to an integer.
     '''
-    success = True
     try:
-        test = int(var)
+        int(var)
     except ValueError:
-        sucess = False
-    return success
+        return False
+    return True
 
 #----------------------------------------------------------------------------------------
 def get_timestamp_substr(total_by):


### PR DESCRIPTION
I found a typo in a pair of functions. Rather than just correct the spelling, I found it easiest to just avoid storing the variable in the first place and return immediately instead.

Prior to this PR, `is_int()` always returns `True`, no matter the input. With this PR, it should work as intended.