### PR TITLE
use left/right arrow keys to move between images in the web interface

### DIFF
--- a/webserver.py
+++ b/webserver.py
@@ -129,6 +129,29 @@ class DirectoryHandler(SimpleHTTPRequestHandler):
         tpath, cur_folder = os.path.split(self.path)
         f.write(b"<html><title>%s %s</title>" % (WEB_PAGE_TITLE.encode('utf-8'), self.path.encode('utf-8')))
         f.write(b"<body>")
+        f.write(b"""
+                <script>
+
+document.onkeydown = checkKey;
+
+function checkKey(e) {
+
+    e = e || window.event;
+
+    var indexOfCurrentImg = Math.max(0, Array.from(document.querySelectorAll('a[target="imgbox"')).map((a) => a.href).indexOf(document.getElementsByTagName("iframe")[0].contentDocument.URL ))
+    var nextA = Array.from(document.querySelectorAll('a[target="imgbox"'))[indexOfCurrentImg-1]
+    var prevA = Array.from(document.querySelectorAll('a[target="imgbox"'))[indexOfCurrentImg+1]
+
+    if (e.keyCode == '37') { // left arrow
+       prevA.click()
+    }
+    else if (e.keyCode == '39') {  // right arrow
+      nextA.click()
+    }
+
+}
+                </script>
+                """)
         # Start Left iframe Image Panel
         f.write(b'<iframe width="%s" height="%s" align="left"'
                 % (WEB_IFRAME_WIDTH_PERCENT.encode('utf-8'), WEB_IMAGE_HEIGHT.encode('utf-8')))


### PR DESCRIPTION
This PR adds a little bit of Javascript in the web interface to let the user use the left/right arrow keys to move between images. Left moves back in time; right moves forward in time.

(Prior to this PR, I was clicking from image to image, which was hard, requiring a context-shift from looking at cars to finding the right link to click, then back to looking at cars.)