### PR TITLE
Feature/warp

### DIFF
--- a/config.py
+++ b/config.py
@@ -109,6 +109,10 @@ MO_CROP_X_LEFT = 50           # Default=50
 MO_CROP_X_RIGHT = 250         # Default=250
 MO_CROP_Y_UPPER = 90          # Default=90
 MO_CROP_Y_LOWER = 150         # Default=150
+MO_WARP_ON = False             # Default False; cv2.warpPerspective using 4+ control points defined below.
+                              # on my 4gb Rpi 4, this costs ~0.17 fps
+MO_WARP_INPUT_PTS =  [[188,345], [179,411], [489,436], [489,363]]
+MO_WARP_OUTPUT_PTS = [[179,363],[179,436],  [489,436], [489,363]]
 
 # Plugins override the specified config.py variable settings
 # ----------------------------------------------------------

--- a/speed-cam.py
+++ b/speed-cam.py
@@ -118,6 +118,9 @@ default_settings = {
     "MO_CROP_X_RIGHT": 250,
     "MO_CROP_Y_UPPER": 90,
     "MO_CROP_Y_LOWER": 150,
+    "MO_WARP_ON": False,
+    "MO_WARP_INPUT_PTS": [1,2,3,4],
+    "MO_WARP_OUTPUT_PTS": [1,2,3,4],
     "CAMERA": "pilibcam",
     "CAM_LOCATION": "Front Window",
     "USBCAM_SRC": 0,
@@ -1151,6 +1154,9 @@ def get_motion_contours(grayimage1):
         image = vs.read()  # Read image data from video steam thread instance
         # crop image to motion tracking area only
         try:
+            if MO_WARP_ON:
+                M = cv2.getPerspectiveTransform(np.float32(MO_WARP_INPUT_PTS),np.float32(MO_WARP_OUTPUT_PTS))
+                image = cv2.warpPerspective(image,M,(image.shape[1], image.shape[0]),flags=cv2.INTER_NEAREST)
             image_crop = image[MO_CROP_Y_UPPER:MO_CROP_Y_LOWER, MO_CROP_X_LEFT:MO_CROP_X_RIGHT]
             image_ok = True
         except (ValueError, TypeError):
@@ -1302,6 +1308,9 @@ def speed_camera():
     # initialize a cropped grayimage1 image
     image2 = vs.read()  # Get image from VideoSteam thread instance
     try:
+        if MO_WARP_ON:
+            M = cv2.getPerspectiveTransform(np.float32(MO_WARP_INPUT_PTS), np.float32(MO_WARP_OUTPUT_PTS))
+            image2 = cv2.warpPerspective(image2,M,(image2.shape[1], image2.shape[0]),flags=cv2.INTER_NEAREST)
         # crop image to motion tracking area only
         image_crop = image2[MO_CROP_Y_UPPER:MO_CROP_Y_LOWER, MO_CROP_X_LEFT:MO_CROP_X_RIGHT]
     except:

--- a/webserver.py
+++ b/webserver.py
@@ -129,6 +129,29 @@ class DirectoryHandler(SimpleHTTPRequestHandler):
         tpath, cur_folder = os.path.split(self.path)
         f.write(b"<html><title>%s %s</title>" % (WEB_PAGE_TITLE.encode('utf-8'), self.path.encode('utf-8')))
         f.write(b"<body>")
+        f.write(b"""
+                <script>
+
+document.onkeydown = checkKey;
+
+function checkKey(e) {
+
+    e = e || window.event;
+
+    var indexOfCurrentImg = Math.max(0, Array.from(document.querySelectorAll('a[target="imgbox"')).map((a) => a.href).indexOf(document.getElementsByTagName("iframe")[0].contentDocument.URL ))
+    var nextA = Array.from(document.querySelectorAll('a[target="imgbox"'))[indexOfCurrentImg-1]
+    var prevA = Array.from(document.querySelectorAll('a[target="imgbox"'))[indexOfCurrentImg+1]
+
+    if (e.keyCode == '37') { // left arrow
+       prevA.click()
+    }
+    else if (e.keyCode == '39') {  // right arrow
+      nextA.click()
+    }
+
+}
+                </script>
+                """)
         # Start Left iframe Image Panel
         f.write(b'<iframe width="%s" height="%s" align="left"'
                 % (WEB_IFRAME_WIDTH_PERCENT.encode('utf-8'), WEB_IMAGE_HEIGHT.encode('utf-8')))


### PR DESCRIPTION
Adds a `MO_WARP_ON` option that, if `True`, uses opencv's perspective warp to warp the image such that the four points specified in `MO_WARP_INPUT_PTS` become located at the points specified in `MO_WARP_OUTPUT_PTS`.

The points are specified as a list of two-element lists. The points are in clockwise format [bottom-left, top-left, top right, bottom right]. The points are calculated against the 320x240 image (not the source resolution of the camera).

On my 4gb Raspberry Pi 4, this costs about 1% of FPS (from 16.17fps to 15.98fps) -- i.e. the performance cost is negligible.

The reason for this PR is that my street curves within the motion tracking crop area -- so pixel distances within the crop area don't have a consistent relationship to real-world distances in feet/meters/miles. I decided to crop the area to make the distances consistent.

I don't anticipate that this PR is ready to be merged right away, so happy to address any questions.